### PR TITLE
chore: add bats e2e smoke tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,6 +26,18 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm ci
+      - run: npm run build
+      - run: npm run e2e
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/e2e/smoke.bats
+++ b/e2e/smoke.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+@test "Common JS smoke test" {
+    run node ./e2e/smoke.cjs
+    assert_output 'e781c3c3c3c3819f'
+}
+
+@test "ESM smoke test" {
+    run node ./e2e/smoke.mjs
+    assert_output 'e781c3c3c3c3819f'
+}

--- a/e2e/smoke.cjs
+++ b/e2e/smoke.cjs
@@ -1,0 +1,5 @@
+const imghash = require("../dist/index.js");
+
+imghash.hash(__dirname + "/../assets/absolut2").then((hash) => {
+  console.log(hash); // e781c3c3c3c3819f
+});

--- a/e2e/smoke.mjs
+++ b/e2e/smoke.mjs
@@ -1,0 +1,10 @@
+import imghash from "../dist/index.mjs";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const hash = await imghash.hash(__dirname + "/../assets/absolut2");
+
+console.log(hash); // e781c3c3c3c3819f

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
         "@types/node": "^24.1.0",
         "@typescript-eslint/eslint-plugin": "^8.38.0",
         "@typescript-eslint/parser": "^8.38.0",
+        "bats": "^1.12.0",
+        "bats-assert": "^2.0.0",
+        "bats-support": "^0.2.0",
         "eslint": "^9.31.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.1",
@@ -1679,6 +1682,31 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bats": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/bats/-/bats-1.12.0.tgz",
+      "integrity": "sha512-1HTv2n+fjn3bmY9SNDgmzS6bjoKtVlSK2pIHON5aSA2xaqGkZFoCCWP46/G6jm9zZ7MCi84mD+3Byw4t3KGwBg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "bats": "bin/bats"
+      }
+    },
+    "node_modules/bats-assert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bats-assert/-/bats-assert-2.0.0.tgz",
+      "integrity": "sha512-qO3kNilWxW8iCONu9NDUfvsCiC6JzL6DPOc/DGq9z3bZ9/A7wURJ+FnFMxGbofOmWbCoy7pVhofn0o47A95qkQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "peerDependencies": {
+        "bats-support": "git+https://github.com/ztombol/bats-support.git#v0.2.0"
+      }
+    },
+    "node_modules/bats-support": {
+      "version": "0.2.0",
+      "resolved": "git+ssh://git@github.com/ztombol/bats-support.git#d0a131831c487a1f1141e76d3ab386c89642cdff",
+      "dev": true
     },
     "node_modules/blockhash-core": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "lint": "eslint src",
     "typecheck": "tsc --noEmit",
     "test": "vitest",
+    "e2e": "bats e2e/*.bats",
     "build": "tsup src/index.ts --format=cjs,esm --dts --cjsInterop",
     "dev": "tsup src/index.ts --format cjs --watch"
   },
@@ -29,14 +30,14 @@
     "node": ">=20"
   },
   "homepage": "https://github.com/pwlmc/imghash#readme",
-  "main": "dist/index.js", 
+  "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",   
-      "require": "./dist/index.js" 
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     }
   },
   "type": "commonjs",
@@ -49,6 +50,9 @@
     "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.38.0",
     "@typescript-eslint/parser": "^8.38.0",
+    "bats": "^1.12.0",
+    "bats-assert": "^2.0.0",
+    "bats-support": "^0.2.0",
     "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.1",


### PR DESCRIPTION
- Adds [bats](https://github.com/bats-core/bats-core) to the project
- Writes basic smoke tests for esm and cjs modules